### PR TITLE
Add second patch to 1.17.6 as well.

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -7,7 +7,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -7,7 +7,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:

--- a/recipe/0001-Add-second-downstream-patch.patch
+++ b/recipe/0001-Add-second-downstream-patch.patch
@@ -1,0 +1,26 @@
+From 636e7dcfe2e23d9cea8f260d151e6b04bc8c4eb8 Mon Sep 17 00:00:00 2001
+From: BastianZim <10774221+BastianZim@users.noreply.github.com>
+Date: Sun, 3 Oct 2021 14:50:44 +0200
+Subject: [PATCH] Add second downstream patch
+
+---
+ Clp/src/OsiClp/osi-clp.pc.in | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/Clp/src/OsiClp/osi-clp.pc.in b/Clp/src/OsiClp/osi-clp.pc.in
+index aeb04e93..af1114f7 100644
+--- a/Clp/src/OsiClp/osi-clp.pc.in
++++ b/Clp/src/OsiClp/osi-clp.pc.in
+@@ -7,6 +7,7 @@ Name: OsiClp
+ Description: COIN-OR Open Solver Interface for CLP
+ URL: https://projects.coin-or.org/Osi
+ Version: @PACKAGE_VERSION@
+-Libs: -L${libdir} -lOsiClp @OSICLPLIB_PCLIBS@
++Libs: -L${libdir} -lOsiClp
++Libs.private: @OSICLPLIB_PCLIBS@
+ Cflags: -I${includedir}
+-Requires: clp @OSICLPLIB_PCREQUIRES@
++Requires.private: clp @OSICLPLIB_PCREQUIRES@
+-- 
+2.33.0
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,10 @@ source:
     sha256: ef412cde00cb1313d9041115a700d8d59d4b8b8b5e4dde43e9deb5108fcfbea8
     patches:
        - 0001-Patch-for-downstream.patch
+       - 0001-Add-second-downstream-patch.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "coin-or-clp" %}
-{% set version = "1.17.4" %}
+{% set version = "1.17.6" %}
 
 package:
   name: {{ name|lower }}
@@ -7,13 +7,13 @@ package:
 
 source:
     url: https://github.com/coin-or/Clp/archive/releases/{{ version }}.tar.gz
-    sha256: ef412cde00cb1313d9041115a700d8d59d4b8b8b5e4dde43e9deb5108fcfbea8
+    sha256: afff465b1620cfcbb7b7c17b5d331d412039650ff471c4160c7eb24ae01284c9
     patches:
        - 0001-Patch-for-downstream.patch
        - 0001-Add-second-downstream-patch.patch
 
 build:
-  number: 1
+  number: 3
   skip: true  # [win]
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This PR adds the second patch to 1.17.6. Currently, the second patch is only applied to 1.17.4 through https://github.com/conda-forge/coin-or-clp-feedstock/pull/6 

https://github.com/conda-forge/coin-or-clp-feedstock/pull/6 needs to get merged first.

Build number comes from https://github.com/conda-forge/coin-or-clp-feedstock/commit/c8485e4706d9ade5fa8ff04553c37dd6b73f5859