### PR TITLE
Link to CoinUtils.lib only; remove direct MKL linkage in Clp build

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -9,7 +9,7 @@ else
 fi
 
 if [[ "${target_platform}" == win-* ]]; then
-  COINUTILS_LIB=( --with-coinutils-lib='${LIBRARY_PREFIX}/lib/mkl_rt.lib ${LIBRARY_PREFIX}/lib/libCoinUtils.lib' )
+  COINUTILS_LIB=( --with-coinutils-lib='${LIBRARY_PREFIX}/lib/libCoinUtils.lib' )
   COINUTILS_INC=( --with-coinutils-incdir='${LIBRARY_PREFIX_COIN}' )
   OSI_LIB=( --with-osi-lib='${LIBRARY_PREFIX}/lib/libOsi.lib' )
   OSI_INC=( --with-osi-incdir='${LIBRARY_PREFIX_COIN}' )

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -13,7 +13,7 @@ if [[ "${target_platform}" == win-* ]]; then
   COINUTILS_INC=( --with-coinutils-incdir='${LIBRARY_PREFIX_COIN}' )
   OSI_LIB=( --with-osi-lib='${LIBRARY_PREFIX}/lib/libOsi.lib' )
   OSI_INC=( --with-osi-incdir='${LIBRARY_PREFIX_COIN}' )
-  EXTRA_FLAGS=( --enable-msvc=MD ) 
+  EXTRA_FLAGS=( --enable-msvc=MD --with-blas-lib='${LIBRARY_PREFIX}/lib/mkl_rt.lib' )
 else
   # Get an updated config.sub and config.guess (for mac arm and lnx aarch64)
   cp $BUILD_PREFIX/share/gnuconfig/config.* ./Clp 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -9,7 +9,7 @@ else
 fi
 
 if [[ "${target_platform}" == win-* ]]; then
-  COINUTILS_LIB=( --with-coinutils-lib='${LIBRARY_PREFIX}/lib/libCoinUtils.lib' )
+  COINUTILS_LIB=( --with-coinutils-lib='${LIBRARY_PREFIX}/lib/mkl_rt.lib ${LIBRARY_PREFIX}/lib/libCoinUtils.lib' )
   COINUTILS_INC=( --with-coinutils-incdir='${LIBRARY_PREFIX_COIN}' )
   OSI_LIB=( --with-osi-lib='${LIBRARY_PREFIX}/lib/libOsi.lib' )
   OSI_INC=( --with-osi-incdir='${LIBRARY_PREFIX_COIN}' )

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -9,11 +9,11 @@ else
 fi
 
 if [[ "${target_platform}" == win-* ]]; then
-  COINUTILS_LIB=( --with-coinutils-lib='${LIBRARY_PREFIX}/lib/libCoinUtils.lib' )
+  COINUTILS_LIB=( --with-coinutils-lib='${LIBRARY_PREFIX}/lib/mkl_rt.lib ${LIBRARY_PREFIX}/lib/libCoinUtils.lib' )
   COINUTILS_INC=( --with-coinutils-incdir='${LIBRARY_PREFIX_COIN}' )
   OSI_LIB=( --with-osi-lib='${LIBRARY_PREFIX}/lib/libOsi.lib' )
   OSI_INC=( --with-osi-incdir='${LIBRARY_PREFIX_COIN}' )
-  EXTRA_FLAGS=( --enable-msvc=MD --with-blas-lib='${LIBRARY_PREFIX}/lib/mkl_rt.lib' )
+  EXTRA_FLAGS=( --enable-msvc=MD )
 else
   # Get an updated config.sub and config.guess (for mac arm and lnx aarch64)
   cp $BUILD_PREFIX/share/gnuconfig/config.* ./Clp 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,12 @@ requirements:
   host:
     - coin-or-utils
     - coin-or-osi
-    - mkl-devel
+    - blas-devel
+    - libblas  # [unix]
+    - libcblas
+    - liblapack
+    - liblapacke  # [unix]
+    - mkl-devel  # [win]
     - zlib
     - bzip2
   run_constrained:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,7 @@ requirements:
   host:
     - coin-or-utils
     - coin-or-osi
+    - mkl-devel  # [win]
     - zlib
     - bzip2
   run_constrained:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,12 +34,6 @@ requirements:
   host:
     - coin-or-utils
     - coin-or-osi
-    - blas-devel
-    - libblas  # [unix]
-    - libcblas
-    - liblapack
-    - liblapacke  # [unix]
-    - mkl-devel  # [win]
     - zlib
     - bzip2
   run_constrained:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,11 +34,6 @@ requirements:
   host:
     - coin-or-utils
     - coin-or-osi
-    - blas-devel
-    - libblas  # [unix]
-    - libcblas
-    - liblapack
-    - liblapacke  # [unix]
     - mkl-devel  # [win]
     - zlib
     - bzip2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,6 @@ requirements:
   host:
     - coin-or-utils
     - coin-or-osi
-    - mkl-devel  # [win]
     - zlib
     - bzip2
   run_constrained:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,7 @@ requirements:
   host:
     - coin-or-utils
     - coin-or-osi
+    - mkl-devel
     - zlib
     - bzip2
   run_constrained:


### PR DESCRIPTION
CoinUtils is already linked against MKL during its own build process.
Clp itself does not make direct BLAS/LAPACK or MKL calls.
Therefore, explicitly passing MKL libraries during Clp's build is unnecessary and may lead to unresolved symbols or linking conflicts.